### PR TITLE
Add context manager usage on examples

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -13,6 +13,12 @@ Usage as decorator
 .. literalinclude:: ../examples/decorator.py
 
 
+Usage as context manager
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. literalinclude:: ../examples/context_manager.py
+
+
 Timeout retry cycle limit
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
As we have the example is available on the examples folder it makes sense to include it on the docs also.

