### PR TITLE
Re-raise exception instance instead of creating a new exception with no args

### DIFF
--- a/riprova/retrier.py
+++ b/riprova/retrier.py
@@ -310,5 +310,5 @@ class Retrier(object):
 
     def __exit__(self, exc_type, exc_value, traceback):
         # Forward error, if needed
-        if exc_type:
-            raise exc_type
+        if exc_value:
+            raise exc_value

--- a/tests/retrier_test.py
+++ b/tests/retrier_test.py
@@ -221,3 +221,9 @@ def test_retrier_context_manager(MagicMock):
 
     assert retrier.attempts == 3
     assert isinstance(retrier.error, SyntaxError)
+
+def test_retrier_context_manager_forward_error_message():
+    with pytest.raises(RuntimeError) as excinfo:
+        with Retrier() as retry:
+            raise RuntimeError('Error message here.')
+    assert str(excinfo.value) == 'Error message here.'

--- a/tests/retrier_test.py
+++ b/tests/retrier_test.py
@@ -222,8 +222,9 @@ def test_retrier_context_manager(MagicMock):
     assert retrier.attempts == 3
     assert isinstance(retrier.error, SyntaxError)
 
+
 def test_retrier_context_manager_forward_error_message():
     with pytest.raises(RuntimeError) as excinfo:
-        with Retrier() as retry:
+        with Retrier():
             raise RuntimeError('Error message here.')
     assert str(excinfo.value) == 'Error message here.'


### PR DESCRIPTION
Currently, the context manager re-raises exception by its type with no args. So, there is no error message anymore.
Besides it In some cases, args are mandatory and such behavior may lead to weird error messages.
So, we must re-raise an existing exception instance instead of creating the new one.