### PR TITLE
fix async_retrier in python 3.10

### DIFF
--- a/riprova/async_retrier.py
+++ b/riprova/async_retrier.py
@@ -6,6 +6,8 @@ from .retrier import Retrier
 from .errors import ErrorWhitelist
 from .strategies import ConstantBackoff
 from .exceptions import MaxRetriesExceeded, RetryError
+from riprova.constants import PY_310
+
 
 
 class AsyncRetrier(Retrier):
@@ -47,8 +49,8 @@ class AsyncRetrier(Retrier):
             and should return nothing.
         sleep_coro (coroutinefunction): optional coroutine function used to
             sleep. Defaults to `asyncio.sleep`.
-        loop (asyncio.BaseException): Deprecated and no longer used.
-            Will always using `asyncio.get_event_loop()`.
+        loop (asyncio.BaseException): Deprecated.
+            Will always using `asyncio.get_event_loop()` in python 3.10 and above.
 
     Attributes:
         whitelist (riprova.ErrorWhitelist): default error whitelist instance
@@ -109,14 +111,16 @@ class AsyncRetrier(Retrier):
                  evaluator=None,
                  error_evaluator=None,
                  on_retry=None,
-                 sleep_coro=None
-                 ):
+                 sleep_coro=None,
+                 loop=None):
 
         # Assert input params
         if timeout is not None:
             assert isinstance(timeout, (int, float)), 'timeout must be number'
             assert timeout >= 0, 'timeout cannot be a negative number'
 
+        # Event loop to use
+        self.loop = loop or asyncio.get_event_loop()
         # Stores number of retry attempts
         self.attempts = 0
         # Stores latest error
@@ -264,10 +268,17 @@ class AsyncRetrier(Retrier):
         self.attempts = 0
 
         # If not timeout defined, run the coroutine function
-        return await asyncio.wait_for(
-            self._run(coro, *args, **kw),
-            self.timeout
-        )
+        if PY_310:
+            return await asyncio.wait_for(
+                self._run(coro, *args, **kw),
+                self.timeout
+            )
+        else:
+            return await asyncio.wait_for(
+                self._run(coro, *args, **kw),
+                self.timeout,
+                loop=self.loop
+            )
 
     async def __aenter__(self):
         return self

--- a/riprova/async_retrier.py
+++ b/riprova/async_retrier.py
@@ -47,8 +47,8 @@ class AsyncRetrier(Retrier):
             and should return nothing.
         sleep_coro (coroutinefunction): optional coroutine function used to
             sleep. Defaults to `asyncio.sleep`.
-        loop (asyncio.BaseException): event loop to use.
-            Defaults to `asyncio.get_event_loop()`.
+        loop (asyncio.BaseException): Deprecated and no longer used.
+            Will always using `asyncio.get_event_loop()`.
 
     Attributes:
         whitelist (riprova.ErrorWhitelist): default error whitelist instance
@@ -109,16 +109,14 @@ class AsyncRetrier(Retrier):
                  evaluator=None,
                  error_evaluator=None,
                  on_retry=None,
-                 sleep_coro=None,
-                 loop=None):
+                 sleep_coro=None
+                 ):
 
         # Assert input params
         if timeout is not None:
             assert isinstance(timeout, (int, float)), 'timeout must be number'
             assert timeout >= 0, 'timeout cannot be a negative number'
 
-        # Event loop to use
-        self.loop = loop or asyncio.get_event_loop()
         # Stores number of retry attempts
         self.attempts = 0
         # Stores latest error
@@ -268,8 +266,7 @@ class AsyncRetrier(Retrier):
         # If not timeout defined, run the coroutine function
         return await asyncio.wait_for(
             self._run(coro, *args, **kw),
-            self.timeout,
-            loop=self.loop
+            self.timeout
         )
 
     async def __aenter__(self):

--- a/riprova/constants.py
+++ b/riprova/constants.py
@@ -4,6 +4,7 @@ import sys
 # Store if Python runtime is higher or equal to 3.4
 PY_34 = sys.version_info >= (3, 4)
 PY_35 = sys.version_info >= (3, 5)
+PY_310 = sys.version_info >= (3, 10)
 
 # Assertion template errors
 INT_ERROR = '{} param must be an int'


### PR DESCRIPTION
loop was removed from asyncio.wait_for since 3.10

https://docs.python.org/3.10/library/asyncio-task.html#asyncio.wait_for
<img width="854" alt="截屏2023-12-29 17 24 37" src="https://github.com/h2non/riprova/assets/11059301/890b0afa-dd5f-4a40-abb0-79da653650e9">
